### PR TITLE
fix: 解决打包epub时多余的目录层级

### DIFF
--- a/.github/workflows/build-epub-release.yml
+++ b/.github/workflows/build-epub-release.yml
@@ -23,7 +23,9 @@ jobs:
           shopt -s nullglob
           for dir in EPUB/*/ ; do
             name=$(basename "$dir")
-            zip -r "output/epubs/${name}.epub" "$dir"
+            (
+              cd "$dir" && zip -r "../../output/epubs/${name}.epub" ./*
+            )
           done
 
       - name: Create merged ZIPs


### PR DESCRIPTION
目前自动打包的EPUB包含外部文件夹，本PR修复了这个问题。

![image](https://github.com/user-attachments/assets/30f9501b-50c2-4277-97bc-11c66731a6d9)
